### PR TITLE
#68 Utilizando core empacotado nas views de cálculo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ## Badges
 
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=bugs)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=coverage)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-1-MeasureSoftGram-Service&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-1-MeasureSoftGram-Service)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=bugs)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=coverage)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2022-2-MeasureSoftGram-Service&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2022-2-MeasureSoftGram-Service)
 
 
 ## O que é
@@ -102,7 +102,7 @@ Our services are available on [Docker Hub](https://hub.docker.com/):
 ### Wiki
 
 For more informations, you can see our wiki:
-- [Wiki](https://fga-eps-mds.github.io/2021-2-MeasureSoftGram-Doc/).
+- [Wiki](https://fga-eps-mds.github.io/2022-2-MeasureSoftGram-Doc/).
 
 ## Contribute
 
@@ -114,4 +114,4 @@ AGPL-3.0 License
 
 ## Documentation
 
-The documentation of this project can be accessed at this website: [Documentation](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc).
+The documentation of this project can be accessed at this website: [Documentation](https://github.com/fga-eps-mds/2022-2-MeasureSoftGram-Doc).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,24 +8,18 @@ services:
   db:
     container_name: db
     image: postgres:latest
-    restart: on-failure
     ports:
       - "5432:5432"
     volumes:
       - service_postgres_data:/var/lib/postgresql/data
     env_file:
       - ./env-vars/.postgres.env
-    networks:
-      - msg-service-network
 
   service:
     container_name: service
-    restart: on-failure
     build:
       context: .
     command: ["./start_service.sh"]
-    networks:
-      - msg-service-network
     ports:
       - "8080:80" # Main port
       - "8181:8181" # Debug port
@@ -37,11 +31,3 @@ services:
       - ./env-vars/.postgres.env
     depends_on:
       - db
-
-
-networks:
-  # Bridge used to `service` talk to the right postgres `db` service
-  msg-service-network:
-    name: msg-service-network
-    driver: bridge
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ parameterized~=0.8.1
 tox==3.27.1
 django-allauth==0.51.0
 dj-rest-auth==2.2.5
+msgram-core==1.0.0

--- a/src/organizations/management/commands/load_initial_data.py
+++ b/src/organizations/management/commands/load_initial_data.py
@@ -108,13 +108,13 @@ class Command(BaseCommand):
             #         {"key": "runtime_sum_of_build_pipelines_in_the_last_x_days"},
             #     ],
             # },
-            {
-                "key": "team_throughput",
-                "metrics": [
-                    {"key": "number_of_resolved_issues_with_US_label_in_the_last_x_days"},
-                    {"key": "total_number_of_issues_with_US_label_in_the_last_x_days"},
-                ],
-            },
+            # {
+            #     "key": "team_throughput",
+            #     "metrics": [
+            #         {"key": "number_of_resolved_issues_with_US_label_in_the_last_x_days"},
+            #         {"key": "total_number_of_issues_with_US_label_in_the_last_x_days"},
+            #     ],
+            # },
         ]
         for measure_data in supported_measures:
             measure_key = measure_data["key"]
@@ -296,13 +296,13 @@ class Command(BaseCommand):
                     {"key": "passed_tests"},
                 ],
             },
-            {
-                "key": "functional_completeness",
-                "name": "Functional Completeness",
-                "measures": [
-                    {"key": "team_throughput"},
-                ],
-            },
+            # {
+            #     "key": "functional_completeness",
+            #     "name": "Functional Completeness",
+            #     "measures": [
+            #         {"key": "team_throughput"},
+            #     ],
+            # },
         ]
 
         for subcharacteristic in suported_subcharacteristics:
@@ -344,13 +344,13 @@ class Command(BaseCommand):
                     {"key": "modifiability"},
                 ]
             },
-            {
-                "key": "functional_suitability",
-                "name": "Functional Suitability",
-                "subcharacteristics": [
-                    {"key": "functional_completeness"},
-                ]
-            },
+            # {
+            #     "key": "functional_suitability",
+            #     "name": "Functional Suitability",
+            #     "subcharacteristics": [
+            #         {"key": "functional_completeness"},
+            #     ]
+            # },
         ]
         create_suported_characteristics(suported_characteristics)
 

--- a/src/organizations/management/commands/load_initial_data.py
+++ b/src/organizations/management/commands/load_initial_data.py
@@ -28,6 +28,7 @@ from subcharacteristics.models import (
     CalculatedSubCharacteristic,
     SupportedSubCharacteristic,
 )
+from staticfiles import SONARQUBE_SUPPORTED_MEASURES
 
 # Local Imports
 from utils import (
@@ -61,63 +62,8 @@ class Command(BaseCommand):
         Função que popula banco de dados com todas as medidas que são
         suportadas atualmente e as métricas que cada medida é dependente
         """
-        supported_measures = [
-            {
-                "key": "passed_tests",
-                "metrics": [
-                    {"key": "tests"},
-                    {"key": "test_failures"},
-                    {"key": "test_errors"},
-                ],
-            },
-            {
-                "key": "test_builds",
-                "metrics": [
-                    {"key": "test_execution_time"},
-                ],
-            },
-            {
-                "key": "test_coverage",
-                "metrics": [
-                    {"key": "coverage"},
-                ],
-            },
-            {
-                "key": "non_complex_file_density",
-                "metrics": [
-                    {"key": "functions"},
-                    {"key": "complexity"},
-                ],
-            },
-            {
-                "key": "commented_file_density",
-                "metrics": [
-                    {"key": "comment_lines_density"},
-                ],
-            },
-            {
-                "key": "duplication_absense",
-                "metrics": [
-                    {"key": "duplicated_lines_density"},
-                ],
-            },
-            # {
-            #     "key": "ci_feedback_time",
-            #     "metrics": [
-            #         {"key": "number_of_build_pipelines_in_the_last_x_days"},
-            #         {"key": "runtime_sum_of_build_pipelines_in_the_last_x_days"},
-            #     ],
-            # },
-            # {
-            #     "key": "team_throughput",
-            #     "metrics": [
-            #         {"key": "number_of_resolved_issues_with_US_label_in_the_last_x_days"},
-            #         {"key": "total_number_of_issues_with_US_label_in_the_last_x_days"},
-            #     ],
-            # },
-        ]
-        for measure_data in supported_measures:
-            measure_key = measure_data["key"]
+        for measure_data in SONARQUBE_SUPPORTED_MEASURES:
+            measure_key = list(measure_data.keys())[0]
             with contextlib.suppress(IntegrityError):
                 measure_name = utils.namefy(measure_key)
 
@@ -129,8 +75,8 @@ class Command(BaseCommand):
                 logger.info(f"Creating supported measure {measure_key}")
 
                 metrics_keys = {
-                    metric["key"]
-                    for metric in measure_data["metrics"]
+                    metric
+                    for metric in measure_data[measure_key]["metrics"]
                 }
 
                 metrics = SupportedMetric.objects.filter(
@@ -148,7 +94,7 @@ class Command(BaseCommand):
 
     def create_supported_metrics(self):
         self.create_sonarqube_supported_metrics()
-        self.create_github_supported_metrics()
+        # self.create_github_supported_metrics()
 
     def create_sonarqube_supported_metrics(self):
         sonar_endpoint = 'https://sonarcloud.io/api/metrics/search'

--- a/src/pre_configs/models.py
+++ b/src/pre_configs/models.py
@@ -89,6 +89,16 @@ class PreConfig(models.Model):
             'not defined in pre-configuration',
         ))
 
+    def get_characteristic_weight(self, characteristic_key: str) -> float:
+        for characteristic in self.data['characteristics']:
+            if characteristic['key'] == characteristic_key:
+                return characteristic['weight']
+
+        raise utils.exceptions.CharacteristicNotDefinedInPreConfiguration((
+            f'Characteristic {characteristic_key} '
+            'not defined in pre-configuration',
+        ))
+
     def get_characteristics_keys(self):
         return [
             charac['key']

--- a/src/subcharacteristics/views.py
+++ b/src/subcharacteristics/views.py
@@ -1,19 +1,16 @@
+import utils
+from organizations.models import Product, Repository
+from resources import calculate_subcharacteristics
 from rest_framework import mixins, status, viewsets
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
-
-import utils
-from organizations.models import Product, Repository
-from subcharacteristics.models import (
-    CalculatedSubCharacteristic,
-    SupportedSubCharacteristic,
-)
+from subcharacteristics.models import (CalculatedSubCharacteristic,
+                                       SupportedSubCharacteristic)
 from subcharacteristics.serializers import (
     CalculatedSubCharacteristicHistorySerializer,
     LatestCalculatedSubCharacteristicSerializer,
     SubCharacteristicsCalculationsRequestSerializer,
-    SupportedSubCharacteristicSerializer,
-)
+    SupportedSubCharacteristicSerializer)
 from utils.clients import CoreClient
 
 
@@ -80,12 +77,14 @@ class CalculateSubCharacteristicViewSet(
                 'key': subchar.key,
                 'measures': measure_params,
             })
-        response = CoreClient.calculate_subcharacteristic(core_params)
 
-        if response.ok is False:
-            return Response(response.content, status=response.status_code)
+        calculate_response = calculate_subcharacteristics(core_params)
 
-        data = response.json()
+        if calculate_response.get('code'):
+            status_code = calculate_response.pop('code')
+            return calculate_response(calculate_response, status=status_code)
+
+        data = calculate_response
 
         # 4. Save data
         calculated_values = {

--- a/src/utils/exceptions.py
+++ b/src/utils/exceptions.py
@@ -38,5 +38,11 @@ class SubCharacteristicNotDefinedInPreConfiguration(
     pass
 
 
+class CharacteristicNotDefinedInPreConfiguration(
+    EntityNotDefinedInPreConfiguration
+):
+    pass
+
+
 class InvalidPreConfigException(ValueError):
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     pytest-mock
     coverage
     dj_rest_auth
+    msgram-core
     -r requirements.txt
 
 setenv =
@@ -22,6 +23,6 @@ setenv =
 
 commands =
     coverage erase
-    coverage run -m pytest {posargs} --junitxml=./junit.xml
+    coverage run -m pytest src {posargs} --junitxml=./junit.xml
     coverage xml -o coverage.xml
     coverage report


### PR DESCRIPTION
# Mudança do core empacotado

## Descrição
Com o empacotamento do core, as funções de cálculo disponíveis em alguns endpoints ficou duplicado. Esse pr busca não apenas corrigir isso, bem como melhorar a forma como o SQC é calculado e corrigir o bug das métricas adicionando o TRK na análise.

[Refatorar chamadas de métodos do core na service](https://github.com/fga-eps-mds/2022-2-MeasureSoftGram-Doc/issues/68)
[Utilizar métricas do TRK para extrações de dados na Service](https://github.com/fga-eps-mds/2022-2-MeasureSoftGram-Doc/issues/76)

## Porque este Pull Request é necessário?
Descreva o motivo da realização do documento

## Critérios de aceitação

1. [x] Utilizar métodos diretos do core empacotado (msgram-core)
2. [x] Corrigir cálculo do SQC
3. [x] Corrigir agregação das métricas, implementando o TRK